### PR TITLE
Feat/responsive UI => out of scope changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
         <header className="flex justify-between items-center ">
           <div>
             {isConnected && (
-              <h2 className="text-black shadow-lg px-4 py-2 rounded-md bg-white">
+              <h2 className="text-black shadow-lg px-4 py-1 rounded-md bg-white">
                 {txMode === "WRAP" ? "SEP" : "WSEP"} Bal:{" "}
                 {isLoading ? "fetching bal..." : parseFloat(balance).toFixed(4)}
               </h2>

--- a/src/components/ConnectedWalletWrapper.tsx
+++ b/src/components/ConnectedWalletWrapper.tsx
@@ -93,7 +93,7 @@ const ConnectedWalletWrapper = ({ txMode }: TProp) => {
         <input
           className="px-3 py-1 cursor-pointer border-b rounded-xl"
           type="button"
-          value="Set Max"
+          value="Set max"
           onClick={() => {
             const availableBal = +balance;
             setTxAmount(availableBal.toFixed(4));

--- a/src/components/ConnectedWalletWrapper.tsx
+++ b/src/components/ConnectedWalletWrapper.tsx
@@ -43,7 +43,7 @@ const ConnectedWalletWrapper = ({ txMode }: TProp) => {
     }
   }, [txGas, txAmount, balance, isSuccess]);
 
-  const handleTxSubmission = (e: FormEvent) => {
+  const handleTxSubmission = async (e: FormEvent) => {
     e.preventDefault();
 
     const _txAmount = +txAmount;
@@ -67,8 +67,10 @@ const ConnectedWalletWrapper = ({ txMode }: TProp) => {
         break;
     }
 
-    setCanFetchGas(false);
-    resetGas();
+    if (txStatus === "success") {
+      setCanFetchGas(false);
+      resetGas();
+    }
   };
 
   return (
@@ -112,7 +114,7 @@ const ConnectedWalletWrapper = ({ txMode }: TProp) => {
       </div>
 
       <button
-        className={`w-full self-stretch border border-gray-300 disabled:text-red-300 disabled:cursor-not-allowed rounded-[40px] py-4 text-lg md:mt-4`}
+        className={`w-full self-stretch border border-gray-300 disabled:text-red-300 disabled:cursor-not-allowed rounded-[40px] py-[13px]  text-lg md:mt-4`}
         disabled={!!errorMessage}
       >
         {!!errorMessage


### PR DESCRIPTION
A bit out of the scope of this branch, but this PR addresses the following issue:

- applies less padding to affected components - btn, etc.
- applies only bottom border to `Set max` btn
- resetting `txGas` to null and opting out of interval based gas price fetch ONLY when `deposit` tx is `success`